### PR TITLE
Update HTML Proofer config

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ def html_proofer
   puts "HTML Proofer version: #{HTMLProofer::VERSION}"
   HTMLProofer.check_directory("./_site", {
     :allow_hash_href => true,
-    :http_status_ignore => [999] # LinkedIn returning 999
+    :url_ignore => [/linkedin.com/, /keybase.io/]
   }).run
 end
 

--- a/_posts/2015-10-08-gamification-game-design.md
+++ b/_posts/2015-10-08-gamification-game-design.md
@@ -39,7 +39,7 @@ Here are the slides of the presentation:
 <iframe src="https://docs.google.com/presentation/d/1HnAIXn59KBvkuPEcBdDdmD3txtoHRmTW32jdqb7xhjg/embed?start=false&loop=false&delayms=3000" frameborder="0" width="640" height="389"  allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 
 
-[damiani]: http://www.damiani.net
+[damiani]: https://eaesp.fgv.br/en/faculty/wagner-bronze-damiani
 [fgv]: http://eaesp.fgvsp.br/en
 [fgv-ipm]: http://eaesp.fgvsp.br/en/international-activities/exchange
 [fgv-imq]: http://eaesp.fgvsp.br/en/teaching-knowledge/departments/IMQAA


### PR DESCRIPTION
Add the following URLs to be ignored by HTML Proofer:
- linkedin.com
- keybase.io
